### PR TITLE
Revised URL and provided Referer header to play nice with Google

### DIFF
--- a/lib/tts.rb
+++ b/lib/tts.rb
@@ -5,6 +5,7 @@ require 'uri'
 module Tts
   @@default_url = "http://translate.google.com/translate_tts"
   @@user_agent  = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.68 Safari/534.24"  
+  @@referer     = "http://translate.google.com/"
 
   def self.server_url url=nil
     return @@default_url if url.nil?
@@ -57,12 +58,12 @@ module Tts
   def to_url lang
     langs = ['af', 'ar', 'az', 'be', 'bg', 'bn', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'en', 'en_us', 'en_gb', 'en_au', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'ga', 'gl', 'gu', 'hi', 'hr', 'ht', 'hu', 'id', 'is', 'it', 'iw', 'ja', 'ka', 'kn', 'ko', 'la', 'lt', 'lv', 'mk', 'ms', 'mt', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sv', 'sw', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'ur', 'vi', 'yi', 'zh', 'zh-CN', 'zh-TW']
     raise "Not accepted language, accpeted are #{langs * ","}" unless langs.include? lang
-    base = "#{Tts.server_url}?tl=#{lang}&q=#{URI.escape self}"
+    base = "#{Tts.server_url}?tl=#{lang}&ie=UTF-8&client=t&q=#{URI.escape self}"
   end
 
   def fetch_mp3 url, file_name
     begin 
-      content = open(url, "User-Agent" => @@user_agent).read
+      content = open(url, "User-Agent" => @@user_agent, "Referer" => @@referer).read
  
       File.open("temp.mp3", "wb") do |f|
         f.puts content


### PR DESCRIPTION
It appears that Google now errors with a 503 when attempting TTS via the existing version of this gem.  After searching and finding others with the same issue, I collected some adjustments and applied them to the gem.  Specifically, setting the Referer: header and adjusting the GET request slightly to provide some additional parameters seemed to help.  YMMV as Google could change this unpublished API in the future