### PR TITLE
Fix for RSpec, there is some method's name duplication between gems

### DIFF
--- a/lib/tts.rb
+++ b/lib/tts.rb
@@ -16,7 +16,7 @@ module Tts
     parts = validate_text_length(self)
     file_name = self[0..20].generate_file_name if file_name.nil?
     parts.each do |part|
-      url = part.to_url(lang)
+      url = part.to_tts_url(lang)
       fetch_mp3(url, file_name) 
     end
   end
@@ -55,7 +55,7 @@ module Tts
     gsub(/[\x00\/\\:\*\?\"<>\|]/, '_')
   end
 
-  def to_url lang
+  def to_tts_url lang
     langs = ['af', 'ar', 'az', 'be', 'bg', 'bn', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'en', 'en_us', 'en_gb', 'en_au', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'ga', 'gl', 'gu', 'hi', 'hr', 'ht', 'hu', 'id', 'is', 'it', 'iw', 'ja', 'ka', 'kn', 'ko', 'la', 'lt', 'lv', 'mk', 'ms', 'mt', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sv', 'sw', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'ur', 'vi', 'yi', 'zh', 'zh-CN', 'zh-TW']
     raise "Not accepted language, accpeted are #{langs * ","}" unless langs.include? lang
     base = "#{Tts.server_url}?tl=#{lang}&ie=UTF-8&client=tw-ob&q=#{URI.escape self}"

--- a/spec/tts_spec.rb
+++ b/spec/tts_spec.rb
@@ -31,13 +31,13 @@ describe "to_valid_fn method" do
 
 end
 
-describe 'to_url method' do
-  it "to_url should return a correct string" do
-    "hello".to_url("en").should == "http://translate.google.com/translate_tts?tl=en&ie=UTF-8&client=tw-ob&q=hello"
+describe 'to_tts_url method' do
+  it "to_tss_url should return a correct string" do
+    "hello".to_tts_url("en").should == "http://translate.google.com/translate_tts?tl=en&ie=UTF-8&client=tw-ob&q=hello"
   end
 
-  it "to_url should return a correct string with chinese char" do
-    "人民广场".to_url("zh").should == "http://translate.google.com/translate_tts?tl=zh&ie=UTF-8&client=tw-ob&q=%E4%BA%BA%E6%B0%91%E5%B9%BF%E5%9C%BA"
+  it "to_tss_url should return a correct string with chinese char" do
+    "人民广场".to_tts_url("zh").should == "http://translate.google.com/translate_tts?tl=zh&ie=UTF-8&client=tw-ob&q=%E4%BA%BA%E6%B0%91%E5%B9%BF%E5%9C%BA"
   end
 
 end
@@ -89,7 +89,7 @@ describe 'set a server url' do
     Tts.server_url  "http://127.0.0.1:3001/translate_tts"
   end
 
-  it "to_url should return a correct string" do
-    "hello".to_url("en").should == "http://127.0.0.1:3001/translate_tts?tl=en&ie=UTF-8&client=tw-ob&q=hello"
+  it "to_tts_url should return a correct string" do
+    "hello".to_tts_url("en").should == "http://127.0.0.1:3001/translate_tts?tl=en&ie=UTF-8&client=tw-ob&q=hello"
   end
 end


### PR DESCRIPTION
I was enabling tts to use it with the RSpec gem and found that something inside rspec or it's dependencies overrides tts `to_url`. 
Code that I've used is here https://akovtunov.github.io/blog/2017/11/01/teaching-rspec-to-speak/